### PR TITLE
Match branch names using regex. fixes #1

### DIFF
--- a/rbs.go
+++ b/rbs.go
@@ -58,7 +58,7 @@ func Run() {
 
 	searcher := func(input string, index int) bool {
 		branch := branches[index]
-		name := strings.Replace(strings.ToLower(branch.Name), " ", "", -1)
+		name := strings.ReplaceAll(strings.ToLower(branch.Name), " ", "")
 		query := strings.Split(input, " ")
 
 		if query[0] == "$regex" && len(query) > 1 {
@@ -70,7 +70,7 @@ func Run() {
 			return reg.MatchString(name)
 		}
 
-		input = strings.Replace(strings.ToLower(input), " ", "", -1)
+		input = strings.ReplaceAll(strings.ToLower(input), " ", "")
 
 		return strings.Contains(name, input)
 	}

--- a/rbs.go
+++ b/rbs.go
@@ -3,6 +3,7 @@ package rbs
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/manifoldco/promptui"
@@ -58,6 +59,17 @@ func Run() {
 	searcher := func(input string, index int) bool {
 		branch := branches[index]
 		name := strings.Replace(strings.ToLower(branch.Name), " ", "", -1)
+		query := strings.Split(input, " ")
+
+		if query[0] == "$regex" && len(query) > 1 {
+			input = query[1]
+			reg, err := regexp.Compile(input)
+			if err != nil {
+				return false
+			}
+			return reg.MatchString(name)
+		}
+
 		input = strings.Replace(strings.ToLower(input), " ", "", -1)
 
 		return strings.Contains(name, input)

--- a/rbs_test.go
+++ b/rbs_test.go
@@ -34,7 +34,7 @@ func TestSearcher(t *testing.T) {
 	}
 
 	//match branch names container numbers
-	matchedNumBranches := [2]string{"banda005", "323232"}
+	matchedNumBranches := [2]string{}
 	expectedNumBranches := [2]string{"banda005", "323232"}
 	count = 0
 	for key, value := range branches {
@@ -60,6 +60,7 @@ func TestSearcher(t *testing.T) {
 	}
 }
 
+//I had to
 func searcher(input string, index int) bool {
 	branch := branches[index]
 	name := strings.ReplaceAll(strings.ToLower(branch), " ", "")

--- a/rbs_test.go
+++ b/rbs_test.go
@@ -1,0 +1,80 @@
+package rbs
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var branches = []string{"main", "master", "signup", "dawkaka_login", "dawkaka.chat", "webRTC_dawkaka", "pay_two", "pay_one", "socketio_dawkaka", "banda005", "323232"}
+
+func TestSearcher(t *testing.T) {
+	var count int
+	for key, _ := range branches {
+		if searcher("$regex .", key) {
+			count++
+		}
+	}
+	if count != len(branches) {
+		t.Fatalf("Testing ($regex .): expected %d got %d", len(branches), count)
+	}
+
+	//match branch names with only alphabets
+	matchedBranches := [3]string{}
+	expectedBranches := [3]string{"main", "master", "signup"}
+	count = 0
+	for key, value := range branches {
+		if searcher("$regex ^[a-z]([a-z]+)[a-z]$", key) {
+			matchedBranches[count] = value
+			count++
+		}
+	}
+	if expectedBranches != matchedBranches {
+		t.Fatalf("Testing ($regex ^[a-z]([a-z]+)[a-z]$): expected %v got %v", expectedBranches, matchedBranches)
+	}
+
+	//match branch names container numbers
+	matchedNumBranches := [2]string{"banda005", "323232"}
+	expectedNumBranches := [2]string{"banda005", "323232"}
+	count = 0
+	for key, value := range branches {
+		if searcher("$regex [0-9]", key) {
+			matchedNumBranches[count] = value
+			count++
+		}
+	}
+	if expectedNumBranches != matchedNumBranches {
+		t.Fatalf("Testing ($regex ^[0-9]): expected %v got %v", expectedNumBranches, matchedNumBranches)
+	}
+
+	//match branch names with non alphanumberic_ characters
+	want := "dawkaka.chat"
+	var got string
+	for key, value := range branches {
+		if searcher("$regex \\W", key) {
+			got = value
+		}
+	}
+	if want != got {
+		t.Fatalf("Testing ($regex \\W): expected %s got %s", want, got)
+	}
+}
+
+func searcher(input string, index int) bool {
+	branch := branches[index]
+	name := strings.ReplaceAll(strings.ToLower(branch), " ", "")
+	query := strings.Split(input, " ")
+
+	if query[0] == "$regex" && len(query) > 1 {
+		input = query[1]
+		reg, err := regexp.Compile(input)
+		if err != nil {
+			return false
+		}
+		return reg.MatchString(name)
+	}
+
+	input = strings.ReplaceAll(strings.ToLower(input), " ", "")
+
+	return strings.Contains(name, input)
+}


### PR DESCRIPTION
Examples:
![Screenshot from 2022-08-08 12-40-17](https://user-images.githubusercontent.com/49823605/183420625-e6417d26-e2c0-497a-910d-2fde38314db2.png)
![Screenshot from 2022-08-08 12-41-36](https://user-images.githubusercontent.com/49823605/183420698-cf94646d-8bc2-4c83-a897-dbf0155c948c.png)
![Screenshot from 2022-08-08 12-43-49](https://user-images.githubusercontent.com/49823605/183421142-183ccfb8-c361-4e22-a72b-4de0563b81c7.png)

Invalid regex:
![Screenshot from 2022-08-08 12-42-18](https://user-images.githubusercontent.com/49823605/183421485-d76ff0fa-6fea-4b81-af02-874fc4460bdf.png)


